### PR TITLE
Added inputmode="numeric" attribute

### DIFF
--- a/src/single-otp-input.vue
+++ b/src/single-otp-input.vue
@@ -9,6 +9,7 @@
       max="9"
       maxlength="1"
       pattern="[0-9]"
+      inputmode="numeric"
       v-model="model"
       :class="inputClasses"
       @input="handleOnChange"


### PR DESCRIPTION
This will prompt the browser to show a keyboard with numeric key buttons.

The `inputmode` attribute is supported on devices running Chrome 66+ and iOS Safari 12.2+: https://caniuse.com/#search=inputmode