### PR TITLE
Added inputmode attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ input::placeholder {
     <td>Style applied or class passed to each input.</td>
   </tr>
   <tr>
+      <td>inputmode</td>
+      <td>string</td>
+      <td>false</td>
+      <td>"numeric"</td>
+      <td>This allows a browser to display an appropriate virtual keyboard. Optional value: "numeric", "text", "tel". [Learn More](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)</td>
+    </tr>
+  <tr>
+  <tr>
       <td>input-type</td>
       <td>string</td>
       <td>false</td>

--- a/README.md
+++ b/README.md
@@ -166,20 +166,19 @@ input::placeholder {
     <td>Style applied or class passed to each input.</td>
   </tr>
   <tr>
-      <td>inputmode</td>
-      <td>string</td>
-      <td>false</td>
-      <td>"numeric"</td>
-      <td>This allows a browser to display an appropriate virtual keyboard. Optional value: "numeric", "text", "tel". [Learn More](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)</td>
-    </tr>
-  <tr>
-  <tr>
       <td>input-type</td>
       <td>string</td>
       <td>false</td>
       <td>"tel"</td>
       <td>Input type. Optional value: "password", "number", "tel".</td>
-    </tr>
+  </tr>
+  <tr>
+      <td>inputmode</td>
+      <td>string</td>
+      <td>false</td>
+      <td>"numeric"</td>
+      <td>This allows a browser to display an appropriate virtual keyboard. Optional value: "numeric", "text", "tel". [Learn More](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)</td>
+  </tr>
   <tr>
     <td>should-auto-focus</td>
     <td>boolean</td>

--- a/src/single-otp-input.vue
+++ b/src/single-otp-input.vue
@@ -2,6 +2,7 @@
   <div style="display: flex; align-items: center">
     <input
       :type="inputType"
+      :inputmode="inputmode"
       :placeholder="placeholder"
       :disabled="isDisabled"
       ref="input"
@@ -32,6 +33,10 @@ export default defineComponent({
     inputType: {
       type: String,
       default: "tel",
+    },
+    inputmode: {
+      type: String,
+      default: "numeric",
     },
     value: {
       type: [String, Number],

--- a/src/vue3-otp-input.vue
+++ b/src/vue3-otp-input.vue
@@ -33,6 +33,12 @@ export default /* #__PURE__ */ defineComponent({
       validator: (value: string) =>
         ["number", "tel", "password"].includes(value),
     },
+    inputmode: {
+      type: String,
+      validator: (value: string) =>
+        ["numeric", "text", "tel", "none"].includes(value),
+      default: "numeric",
+    },
     shouldAutoFocus: {
       type: Boolean,
       default: false,
@@ -191,6 +197,7 @@ export default /* #__PURE__ */ defineComponent({
       :value="otp[i]"
       :separator="separator"
       :input-type="inputType"
+      :inputmode="inputmode"
       :input-classes="inputClasses"
       :conditionalClass="conditionalClass[i]"
       :is-last-child="i === numInputs - 1"


### PR DESCRIPTION
Improvement to PR #10 

This adds `inputmode` attribute to the top inputs and allows a browser to display an appropriate virtual keyboard.  

The `inputmode` attribute is supported on devices running Chrome 66+ and iOS Safari 12.2+: https://caniuse.com/#search=inputmode

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode