### PR TITLE
Fixed type check for class array

### DIFF
--- a/src/single-otp-input.vue
+++ b/src/single-otp-input.vue
@@ -48,7 +48,7 @@ export default defineComponent({
       type: Boolean,
     },
     inputClasses: {
-      type: String,
+      type: [String, Array as PropType<string[]>],
     },
     conditionalClass: {
       type: String,

--- a/src/vue3-otp-input.vue
+++ b/src/vue3-otp-input.vue
@@ -22,7 +22,7 @@ export default /* #__PURE__ */ defineComponent({
       default: "**",
     },
     inputClasses: {
-      type: String,
+      type: [String, Array as PropType<string[]>],
     },
     conditionalClass: {
       type: Array as PropType<string[]>,


### PR DESCRIPTION
This should stop warnings like the following to appear when passing an array of classes.
![image](https://user-images.githubusercontent.com/19486712/166895794-32c67956-fd06-4665-babd-e07612438c11.png)

might need some additional testing