### PR TITLE
Handle number input with type="text" but retain other number validators.

### DIFF
--- a/src/components/single-otp-input.vue
+++ b/src/components/single-otp-input.vue
@@ -165,7 +165,7 @@ export default defineComponent({
       input,
       model,
       inputTypeValue:
-        props.inputType === "letter-numeric" ? "text" : props.inputType,
+        ["letter-numeric", "number"].includes(props.inputType) ? "text" : props.inputType,
     };
   },
 });

--- a/src/components/vue3-otp-input.vue
+++ b/src/components/vue3-otp-input.vue
@@ -24,7 +24,7 @@ export default /* #__PURE__ */ defineComponent({
     },
     separator: {
       type: String,
-      default: "**",
+      default: "",
     },
     inputClasses: {
       type: [String, Array] as PropType<string[] | string>,
@@ -57,7 +57,7 @@ export default /* #__PURE__ */ defineComponent({
       >,
       validator: (value: string) =>
         ["numeric", "text", "tel", "none"].includes(value),
-      default: "numeric",
+      default: "text",
     },
     shouldAutoFocus: {
       type: Boolean,


### PR DESCRIPTION
This allows numerically validated inputs *without* the up/down arrows.