### PR TITLE
fix: duplicate value when input from right and using 'v-model'

### DIFF
--- a/src/components/vue3-otp-input.vue
+++ b/src/components/vue3-otp-input.vue
@@ -80,8 +80,11 @@ export default /* #__PURE__ */ defineComponent({
     watch(
       () => props.value,
       (val) => {
-        const fill = unref(val).split("");
-        otp.value = fill;
+        // fix issue: https://github.com/ejirocodes/vue3-otp-input/issues/34
+        if (val.length === props.numInputs || otp.value.length === 0) {
+          const fill = unref(val).split('')
+          otp.value = fill
+        }
       },
       { immediate: true }
     );


### PR DESCRIPTION
#34 
Assign 'opt' only when the length of the newly passed 'value' is equal to 'numInputs' or when' opt 'is an empty array.