### PR TITLE
perf: remove redundant `unref()`

### DIFF
--- a/src/components/vue3-otp-input.vue
+++ b/src/components/vue3-otp-input.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, ref, unref, PropType, watch } from "vue";
+import { defineComponent, ref, PropType, watch } from "vue";
 import SingleOtpInput from "./single-otp-input.vue";
 
 // keyCode constants
@@ -86,7 +86,7 @@ export default /* #__PURE__ */ defineComponent({
       (val) => {
         // fix issue: https://github.com/ejirocodes/vue3-otp-input/issues/34
         if (val.length === props.numInputs || otp.value.length === 0) {
-          const fill = unref(val).split('')
+          const fill = val.split('')
           otp.value = fill
         }
       },


### PR DESCRIPTION
`val` in the following code will only be strings so no `unref()` is needed

https://github.com/ejirocodes/vue3-otp-input/blob/ce88c423d42dd4978a1d3596c77a23180a347d47/src/components/vue3-otp-input.vue#L84-L94